### PR TITLE
removed beginning / from details URL

### DIFF
--- a/shop_simplecategories/urls.py
+++ b/shop_simplecategories/urls.py
@@ -11,7 +11,7 @@ urlpatterns = patterns('',
         ShopListView.as_view(model=Category),
         name='category_list'
         ),
-    url(r'^/(?P<slug>[0-9A-Za-z-_.//]+)/$',
+    url(r'^(?P<slug>[0-9A-Za-z-_.//]+)/$',
         CategoryDetailView.as_view(),
         name='category_detail'
         ),


### PR DESCRIPTION
I believe the beginning / is bad and it should always be a trailing / in the parent's urls.py instead.

Imagine: You use the shop with an django-cms apphook. The page that has the apphook is called /shop/. I _think_ the CMS always adds / to the url and then tries to add whatever is in any apphook urls.py files. In this scenario, if we tried to use simplecategories with an apphook and django-cms, the category's get_absolute_url method would produce something like this: /shop//category1/ which is ugly.

It's hard to explain. I hope this makes sense.
