### PR TITLE
Templatetags

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,3 +19,14 @@ form::
 
     class ProductAdmin(admin.ModelAdmin):
         form = ProductForm
+
+
+For your convenience we have added a templatetag ``show_root_categories`` that 
+outputs all root categories for you::
+
+    {% load shop_simplecategories_tags %}
+
+    <ul>{% show_root_categories %}</ul>
+
+If you want to manipulate the output of that template tag, just override the template 
+``shop_simplecategories/show_root_categories.html``

--- a/shop_simplecategories/templates/shop_simplecategories/show_root_categories.html
+++ b/shop_simplecategories/templates/shop_simplecategories/show_root_categories.html
@@ -1,0 +1,3 @@
+{% for category in categories %}
+  <li><a href="{{ category.get_absolute_url }}">{{ category.name }}</a></li>
+{% endfor %}

--- a/shop_simplecategories/templatetags/shop_simplecategories_tags.py
+++ b/shop_simplecategories/templatetags/shop_simplecategories_tags.py
@@ -1,0 +1,17 @@
+from django import template
+
+from classytags.helpers import InclusionTag
+
+from ..models import Category
+
+register = template.Library()
+
+
+class RootCategoryTag(InclusionTag):
+    template = 'shop_simplecategories/show_root_categories.html'
+    name = 'show_root_categories'
+
+    def get_context(self, context):
+        return {'categories': Category.objects.root_categories(),}
+
+register.tag(RootCategoryTag)

--- a/shop_simplecategories/tests/__init__.py
+++ b/shop_simplecategories/tests/__init__.py
@@ -1,2 +1,3 @@
 from categories import CategoriesTestCase
 from views import CategoryDetailViewTestCase
+from templatetags import RootCategoryTagTestCase

--- a/shop_simplecategories/tests/templatetags.py
+++ b/shop_simplecategories/tests/templatetags.py
@@ -1,0 +1,21 @@
+#-*- coding: utf-8 -*-
+from decimal import Decimal
+from django.test.testcases import TestCase
+
+from classytags.tests import DummyParser, DummyTokens
+
+from ..models import Category
+from ..templatetags.shop_simplecategories_tags import RootCategoryTag
+
+
+class RootCategoryTagTestCase(TestCase):
+    def setUp(self):
+        Category.objects.create(name='Parent1')
+        Category.objects.create(name='Parent2')
+        Category.objects.create(name='Parent2', parent_category_id=1)
+            
+    def test01_should_only_return_parent_categories(self):
+        tag = RootCategoryTag(DummyParser(), DummyTokens())
+        result = tag.get_context({})
+        self.assertTrue(result.has_key('categories'))
+        self.assertEqual(len(result['categories']), 2)


### PR DESCRIPTION
just a simple first draft for a {% show_root_categories %} tag
when I'm back from china I want to make it a bit easier to extend, like allowing the template name as a parameter, or allowing a query or allowing the definition of levels similar to the show_menu tag of django_cms
