### PR TITLE
Fix templates to work with django 1.5.

### DIFF
--- a/shop_simplecategories/templates/shop_simplecategories/category_detail.html
+++ b/shop_simplecategories/templates/shop_simplecategories/category_detail.html
@@ -1,5 +1,5 @@
 <h1>{{object.name}}</h1>
 
 {% for product in product_list %}
-<a href="{% url product_detail product.slug %}">{{product.name}}</a>
+<a href="{% url "product_detail" product.slug %}">{{product.name}}</a>
 {% endfor %}

--- a/shop_simplecategories/templates/shop_simplecategories/category_list.html
+++ b/shop_simplecategories/templates/shop_simplecategories/category_list.html
@@ -1,7 +1,7 @@
 <h1>Categories list</h1>
 {% for object in object_list %}
 
-<a href="{% url category_detail object.slug %}">{{object.name}}</a><br />
+<a href="{% url "category_detail" object.slug %}">{{object.name}}</a><br />
 {{object.slug}}
 
 {% endfor %}


### PR DESCRIPTION
This is required for the url template tag in django 1.5. I believe it's backwards compatible too but I haven't tested it with earlier versions.
